### PR TITLE
build: mdx loader should not behind the thread-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@graphql-codegen/cli": "2.8.1",
     "@graphql-codegen/typescript": "^2.7.1",
     "@graphql-codegen/typescript-operations": "^2.5.1",
-    "@mdx-js/loader": "^2.1.2",
+    "@mdx-js/loader": "^2.1.3",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-commonjs": "22.0.1",
     "@rollup/plugin-json": "^4.1.0",

--- a/tools/webpack/webpack.config.ts
+++ b/tools/webpack/webpack.config.ts
@@ -138,7 +138,6 @@ const config: () => webpack.Configuration = () => {
             {
               test: /\.mdx?$/,
               use: [
-                'thread-loader',
                 {
                   loader: '@mdx-js/loader',
                   options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4350,15 +4350,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/loader@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@mdx-js/loader@npm:2.1.2"
+"@mdx-js/loader@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@mdx-js/loader@npm:2.1.3"
   dependencies:
     "@mdx-js/mdx": ^2.0.0
     source-map: ^0.7.0
   peerDependencies:
     webpack: ">=4"
-  checksum: 5fd8978b4835aa8bb94a1f9c3e753839001c8fb1cd2b1d4ed8f03dd17bc1c16c339cecade38dae11d4100cd8414ba0e6042b19a041eee63f25a8bb12c3e1ed54
+  checksum: 087ec51548d194631d2df9d6ae7ebd45000e9a5d67d71068487036edb1d24848a6198574745af7f57916d1e32bdeec4e256cb842296a2f02e75180221e54bc45
   languageName: node
   linkType: hard
 
@@ -19594,7 +19594,7 @@ __metadata:
     "@graphql-codegen/cli": 2.8.1
     "@graphql-codegen/typescript": ^2.7.1
     "@graphql-codegen/typescript-operations": ^2.5.1
-    "@mdx-js/loader": ^2.1.2
+    "@mdx-js/loader": ^2.1.3
     "@rollup/plugin-alias": ^3.1.9
     "@rollup/plugin-commonjs": 22.0.1
     "@rollup/plugin-json": ^4.1.0


### PR DESCRIPTION
```text
TypeError: Cannot read properties of null (reading 'plugins')
    at addPreset (file:///Users/longyinan/workspace/github/perfsee/node_modules/unified/lib/index.js:204:22)
    at add (file:///Users/longyinan/workspace/github/perfsee/node_modules/unified/lib/index.js:192:11)
    at addList (file:///Users/longyinan/workspace/github/perfsee/node_modules/unified/lib/index.js:223:11)
    at Function.use (file:///Users/longyinan/workspace/github/perfsee/node_modules/unified/lib/index.js:166:9)
    at createProcessor (file:///Users/longyinan/workspace/github/perfsee/node_modules/@mdx-js/mdx/lib/core.js:109:6)
    at split (file:///Users/longyinan/workspace/github/perfsee/node_modules/@mdx-js/mdx/lib/util/create-format-aware-processors.js:82:37)
    at process (file:///Users/longyinan/workspace/github/perfsee/node_modules/@mdx-js/mdx/lib/util/create-format-aware-processors.js:45:31)
    at Object.loader (file:///Users/longyinan/workspace/github/perfsee/node_modules/@mdx-js/loader/lib/index.js:65:3)
    at /Users/longyinan/workspace/github/perfsee/node_modules/@mdx-js/loader/index.cjs:14:19
file:///Users/longyinan/workspace/github/perfsee/node_modules/unified/lib/index.js:204
      addList(result.plugins)
```