### PR TITLE
Some test fixes on win32 platform

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -48,7 +48,11 @@ jobs:
           yarn typecheck
 
   unit-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        host: ['ubuntu-latest', 'windows-latest']
+    name: Unit test on - ${{ matrix.host }}
+    runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x

--- a/packages/bundle-analyzer/src/module.ts
+++ b/packages/bundle-analyzer/src/module.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { join, relative, resolve } from 'path'
+import { join, relative, resolve } from 'path/posix'
 
 import { parse as parseQueryString } from 'query-string'
 

--- a/packages/chrome-finder/src/__tests__/find-chrome.spec.ts
+++ b/packages/chrome-finder/src/__tests__/find-chrome.spec.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from 'fs'
 import { join } from 'path'
 
 import test from 'ava'
@@ -5,7 +6,7 @@ import puppeteer from 'puppeteer-core'
 
 import { findChrome } from '..'
 
-test.only('should find local suitable chromium', async (t) => {
+test('should find local suitable chromium', async (t) => {
   const chromeInfo = await findChrome()
 
   t.truthy(chromeInfo.browser)
@@ -18,6 +19,7 @@ test('should throw if chrome version not match', async (t) => {
 
 test('should download if config specified', async (t) => {
   const downloadPath = join(__dirname, '../', '../', 'dist', 'chrome')
+  mkdirSync(downloadPath, { recursive: true })
   const chromeInfo = await findChrome({
     min: 66,
     max: 66,

--- a/packages/chrome-finder/src/win32.ts
+++ b/packages/chrome-finder/src/win32.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { execSync } from 'child_process'
+import { existsSync } from 'fs'
 import { sep, join } from 'path'
 
 import { canAccess } from './utils'
@@ -24,15 +25,19 @@ export function findChromeBinaryOnWin32(canary = false) {
     ? `${sep}Google${sep}Chrome SxS${sep}Application${sep}chrome.exe`
     : `${sep}Google${sep}Chrome${sep}Application${sep}chrome.exe`
 
-  const prefixes = [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']].filter(
-    Boolean,
-  )
+  const prefixes = [
+    process.env.LOCALAPPDATA,
+    process.env.PROGRAMFILES,
+    process.env['PROGRAMFILES(X86)'],
+    process.env.ProgramFiles,
+    process.env['ProgramFiles(x86)'],
+  ].filter(Boolean)
 
   let result: string | undefined
 
   prefixes.forEach((prefix) => {
     const chromePath = join(prefix!, suffix)
-    if (canAccess(chromePath)) {
+    if (existsSync(chromePath) && canAccess(chromePath)) {
       result = chromePath
     }
   })


### PR DESCRIPTION
- [x] chrome finder env variables name
- [x] module name analyzer emit win32 style separator (`\\`) which is unexpected