### PR TITLE
chore(bundle-analyzer): add exports filed for path alias

### DIFF
--- a/packages/bundle-analyzer/package.json
+++ b/packages/bundle-analyzer/package.json
@@ -21,5 +21,16 @@
     "query-string": "^7.1.1",
     "tar": "^6.1.11",
     "tslib": "^2.4.0"
+  },
+  "exports": {
+    ".": {
+      "require": "./dist/index.js"
+    },
+    "./types": {
+      "require": "./dist/types.js"
+    },
+    "./stats": {
+      "require": "./dist/stats.js"
+    }
   }
 }


### PR DESCRIPTION
In this PR, you can run `node packages/runner/executor/dist/index.js` without `path-alias`