### PR TITLE
fix(platform-server): github no email error

### DIFF
--- a/packages/platform-server/src/modules/auth/oauth.controller.ts
+++ b/packages/platform-server/src/modules/auth/oauth.controller.ts
@@ -159,6 +159,10 @@ export class OAuth2Controller {
       return connectedUser
     }
 
+    if (!externAccount.email) {
+      throw new Error('GITHUB_NO_PUBLIC_EMAIL')
+    }
+
     // find registered user by email
     let user = await this.user.findUserByEmail(externAccount.email)
 

--- a/packages/platform-server/src/modules/auth/providers/provider.ts
+++ b/packages/platform-server/src/modules/auth/providers/provider.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 export interface ExternalAccountUser {
   username: string
-  email: string
+  email?: string
   avatarUrl: string
 }
 

--- a/packages/platform/src/modules/login/index.tsx
+++ b/packages/platform/src/modules/login/index.tsx
@@ -29,7 +29,7 @@ import { useModule, useModuleState } from '@sigi/react'
 import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 
-import { BodyContainer, useQueryString } from '@perfsee/components'
+import { BodyContainer, ForeignLink, useQueryString } from '@perfsee/components'
 import { staticPath } from '@perfsee/shared/routes'
 
 import { UserModule } from '../shared'
@@ -57,6 +57,16 @@ const StatusText = {
   },
   EXTERN_USERNAME_TAKEN: {
     message: 'The account has been connected to others, try logging in.',
+    type: MessageBarType.error,
+  },
+  GITHUB_NO_PUBLIC_EMAIL: {
+    message: (
+      <>
+        Your Github account does not have a public email address, please go to{' '}
+        <ForeignLink href="https://github.com/settings/profile">your profile</ForeignLink> to set a public email
+        address, or use <Link to={staticPath.register}>email to register</Link>.
+      </>
+    ),
     type: MessageBarType.error,
   },
 }


### PR DESCRIPTION
If the user has set hidden email address, Oauth2Server may get the github email as null, ask the user to register with email address.

![image](https://user-images.githubusercontent.com/13579374/188095975-ccafb91b-e9e3-46c0-b66e-f73f70f3afd5.png)
