### PR TITLE
fix(platform): wrong MAX/MIN label in competitor RUM comparison table

### DIFF
--- a/packages/components/src/table/index.tsx
+++ b/packages/components/src/table/index.tsx
@@ -156,8 +156,15 @@ export function Table<T = any>({
       let worstItemIndex = 0
 
       rawItems.forEach((v, i) => {
-        bestItemIndex = column.comparator!(rawItems[bestItemIndex], v) < 0 ? bestItemIndex : i
-        worstItemIndex = column.comparator!(rawItems[worstItemIndex], v) > 0 ? worstItemIndex : i
+        const best = column.comparator!(rawItems[bestItemIndex], v)
+        if (typeof best === 'number') {
+          bestItemIndex = best < 0 ? bestItemIndex : i
+        }
+
+        const worst = column.comparator!(rawItems[worstItemIndex], v)
+        if (typeof worst === 'number') {
+          worstItemIndex = worst > 0 ? worstItemIndex : i
+        }
       })
 
       items = rawItems.map((item, i) => {

--- a/packages/platform/src/modules/competitor/competitor-metrics.tsx
+++ b/packages/platform/src/modules/competitor/competitor-metrics.tsx
@@ -106,7 +106,12 @@ export const CompetitorMetricsChart: FC<Props> = ({ reports }) => {
       )
 
       const content = (
-        <SnapshotChartTooltip title={Metrics[measure].title} formatter={formatter} dataList={items} project={project} />
+        <SnapshotChartTooltip
+          title={Metrics[measure].title}
+          formatter={formatter}
+          dataList={items.sort((a, b) => b.data.value - a.data.value)}
+          project={project}
+        />
       )
 
       return renderTooltip('competitor-metrics', content)

--- a/packages/platform/src/modules/competitor/competitor-table.tsx
+++ b/packages/platform/src/modules/competitor/competitor-table.tsx
@@ -52,11 +52,13 @@ const metricColumns = ['FCP', 'FMP', 'LCP', 'SI', 'TTI', 'TBT', 'WS'].map((key) 
     comparator: (a, b) => {
       const aPayload = a[MetricType[key]]
       const bPayload = b[MetricType[key]]
-      if (!aPayload || !bPayload || !aPayload.sample.length || !bPayload.sample.length) {
-        return 0
+      if (!aPayload?.sample.length || !bPayload?.sample.length) {
+        return undefined
       }
-      const aMean = getMean(aPayload.sample)
+
       const bMean = getMean(bPayload.sample)
+      const aMean = getMean(aPayload.sample)
+
       return aMean - bMean
     },
     onRender: (item) => {


### PR DESCRIPTION
close #191 
<img width="454" alt="image" src="https://user-images.githubusercontent.com/11516663/201291499-04b9cd3e-5eac-4e80-932c-0a00b19d0d0f.png">

sort by value
<img width="704" alt="image" src="https://user-images.githubusercontent.com/11516663/201291577-2aaa1011-f9eb-4690-87ac-17457568c7a1.png">
