### PR TITLE
feat(platform): install app page

### DIFF
--- a/packages/platform-server/src/db/mysql/user.entity.ts
+++ b/packages/platform-server/src/db/mysql/user.entity.ts
@@ -76,7 +76,7 @@ export class User extends BaseEntity {
 }
 
 @ObjectType()
-export class Application extends PickType(User, ['username', 'createdAt']) {
+export class Application extends PickType(User, ['username', 'avatarUrl', 'createdAt']) {
   @Field(() => Int)
   id!: number
 }

--- a/packages/platform-server/src/modules/application/__tests__/application.spec.e2e.ts
+++ b/packages/platform-server/src/modules/application/__tests__/application.spec.e2e.ts
@@ -51,7 +51,7 @@ test.serial('create application', async (t) => {
   const response = await gqlClient.query({
     query: applicationQuery,
     variables: {
-      id: createResponse.createApplication.application.id,
+      name: createResponse.createApplication.application.username,
     },
   })
 

--- a/packages/platform-server/src/modules/project/resolver.ts
+++ b/packages/platform-server/src/modules/project/resolver.ts
@@ -85,8 +85,21 @@ export class ProjectResolver {
       description: 'search project with git namespace/name',
     })
     query: string | undefined,
+    @Args({
+      name: 'permission',
+      nullable: true,
+      type: () => Permission,
+      description: 'filter project with permission',
+    })
+    permission: Permission | undefined,
   ): Promise<PaginatedType<Project>> {
-    const [projects, totalCount] = await this.projectService.getProjects(user, paginationInput, query, starred)
+    const [projects, totalCount] = await this.projectService.getProjects(
+      user,
+      paginationInput,
+      query,
+      starred,
+      permission,
+    )
     return paginate(projects, 'id', paginationInput, totalCount)
   }
 

--- a/packages/platform/src/icons.tsx
+++ b/packages/platform/src/icons.tsx
@@ -60,6 +60,8 @@ import {
   DesktopOutlined,
   ApiOutlined,
   GlobalOutlined,
+  FileSearchOutlined,
+  FileProtectOutlined,
 } from '@ant-design/icons'
 import { registerIcons } from '@fluentui/react'
 import { PlugConnectedIcon, PlugDisconnectedIcon, HideIcon, RedEyeIcon } from '@fluentui/react-icons-mdl2'
@@ -125,6 +127,8 @@ registerIcons({
     desktop: <DesktopOutlined />,
     ping: <ApiOutlined />,
     global: <GlobalOutlined />,
+    fileSearch: <FileSearchOutlined />,
+    fileProtect: <FileProtectOutlined />,
 
     // for password text field
     Hide: <HideIcon />,

--- a/packages/platform/src/modules/apps/index.ts
+++ b/packages/platform/src/modules/apps/index.ts
@@ -1,0 +1,1 @@
+export * from './installer'

--- a/packages/platform/src/modules/apps/installer.module.ts
+++ b/packages/platform/src/modules/apps/installer.module.ts
@@ -1,0 +1,110 @@
+/*
+Copyright 2022 ByteDance and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Module, EffectModule, Effect, ImmerReducer } from '@sigi/core'
+import { Draft } from 'immer'
+import { Observable } from 'rxjs'
+import { switchMap, map, startWith, endWith } from 'rxjs/operators'
+
+import { createErrorCatcher, GraphQLClient } from '@perfsee/platform/common'
+import { applicationQuery, ApplicationQuery, authorizeApplicationMutation, Permission } from '@perfsee/schema'
+
+export type Application = ApplicationQuery['application']
+
+interface State {
+  application: Application | null
+  loading: boolean
+  installing: boolean
+  installSuccess: boolean
+}
+
+@Module('ApplicationInstallerModule')
+export class ApplicationInstallerModule extends EffectModule<State> {
+  defaultState = {
+    application: null,
+    loading: false,
+    installing: false,
+    installSuccess: false,
+  }
+
+  constructor(private readonly client: GraphQLClient) {
+    super()
+  }
+
+  @Effect()
+  getApplication(payload$: Observable<{ appName: string }>) {
+    return payload$.pipe(
+      switchMap(({ appName }) =>
+        this.client
+          .query({
+            query: applicationQuery,
+            variables: { name: appName },
+          })
+          .pipe(
+            map((data) => {
+              return this.getActions().setApplication(data.application)
+            }),
+            startWith(this.getActions().setLoading(true)),
+            endWith(this.getActions().setLoading(false)),
+            createErrorCatcher('Failed to fetch application'),
+          ),
+      ),
+    )
+  }
+
+  @Effect()
+  authNewApplications(payload$: Observable<{ projectId: string; applicationId: number; permissions: Permission[] }>) {
+    return payload$.pipe(
+      switchMap(({ projectId, applicationId, permissions }) =>
+        this.client
+          .query({
+            query: authorizeApplicationMutation,
+            variables: {
+              projectId,
+              applicationId,
+              permissions,
+            },
+          })
+          .pipe(
+            createErrorCatcher('Failed to auth new applications.'),
+            map(() => this.getActions().setInstallSuccess(true)),
+            startWith(this.getActions().setInstalling(true)),
+            endWith(this.getActions().setInstalling(false)),
+          ),
+      ),
+    )
+  }
+
+  @ImmerReducer()
+  setApplication(state: Draft<State>, payload: Application) {
+    state.application = payload
+  }
+
+  @ImmerReducer()
+  setLoading(state: Draft<State>, loading: boolean) {
+    state.loading = loading
+  }
+
+  @ImmerReducer()
+  setInstallSuccess(state: Draft<State>, installSuccess: boolean) {
+    state.installSuccess = installSuccess
+  }
+
+  @ImmerReducer()
+  setInstalling(state: Draft<State>, installing: boolean) {
+    state.installing = installing
+  }
+}

--- a/packages/platform/src/modules/apps/installer.tsx
+++ b/packages/platform/src/modules/apps/installer.tsx
@@ -1,0 +1,268 @@
+import {
+  Stack,
+  Text,
+  SelectionMode,
+  Persona,
+  Spinner,
+  SpinnerSize,
+  SharedColors,
+  PrimaryButton,
+  ChoiceGroup,
+  IChoiceGroupOption,
+  IconButton,
+} from '@fluentui/react'
+import { useModule } from '@sigi/react'
+import { useCallback, useEffect, useState } from 'react'
+import { useParams } from 'react-router'
+
+import { BodyContainer, Pagination, useQueryString, Table } from '@perfsee/components'
+import { Permission } from '@perfsee/schema'
+import { pathFactory, RouteTypes } from '@perfsee/shared/routes'
+
+import { ProjectNode, ProjectsModule } from '../project/list.module'
+import { ProjectModule } from '../shared'
+
+import { ApplicationInstallerModule } from './installer.module'
+import { CardContainer, CenterText, ProjectSearchBar, SelectorContainer, Title } from './style'
+
+const Authorization = ({ projectId, appId }: { projectId: string; appId: number }) => {
+  const [{ project, loading }, dispatcher] = useModule(ProjectModule)
+  const [{ returnUrl, action }, updateQueryString] = useQueryString<{ action: string; returnUrl: string }>()
+
+  const [{ installSuccess, installing }, installerDispatcher] = useModule(ApplicationInstallerModule)
+
+  useEffect(() => {
+    dispatcher.getProject({ projectId })
+    return dispatcher.reset
+  }, [dispatcher, projectId])
+
+  const handleChangeAction = useCallback(
+    (_e: any, option?: IChoiceGroupOption) => {
+      updateQueryString({ action: option?.key })
+    },
+    [updateQueryString],
+  )
+
+  const handleClickInstall = useCallback(() => {
+    installerDispatcher.authNewApplications({
+      projectId,
+      applicationId: appId,
+      permissions: action === 'Admin' ? [Permission.Admin, Permission.Read] : [Permission.Read],
+    })
+  }, [action, appId, installerDispatcher, projectId])
+
+  useEffect(() => {
+    if (installSuccess) {
+      const timeout = setTimeout(() => {
+        location.href = returnUrl || pathFactory.project.settings({ projectId, settingName: 'basic' })
+      }, 3000)
+
+      return () => {
+        clearTimeout(timeout)
+      }
+    }
+  }, [installSuccess, projectId, returnUrl])
+
+  const hasPermission = !!project?.userPermission.includes(Permission.Admin)
+
+  if (loading) {
+    return <Spinner size={SpinnerSize.large} />
+  }
+
+  if (!hasPermission) {
+    return (
+      <Stack tokens={{ childrenGap: 32 }}>
+        <CenterText>
+          <>You don't has admin permission for the project '{projectId}'</>
+        </CenterText>
+        <PrimaryButton disabled>Install</PrimaryButton>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack tokens={{ childrenGap: 32 }}>
+      <Stack horizontal>
+        <ChoiceGroup
+          options={[
+            { key: 'Admin', text: 'Admin', iconProps: { iconName: 'fileProtect' } },
+            { key: 'Read', text: 'Read', iconProps: { iconName: 'fileSearch' } },
+          ]}
+          defaultSelectedKey={action}
+          onChange={handleChangeAction}
+        />
+      </Stack>
+      {installSuccess ? (
+        <PrimaryButton disabled>redirecting...</PrimaryButton>
+      ) : (
+        <PrimaryButton onClick={handleClickInstall} disabled={(action !== 'Admin' && action !== 'Read') || installing}>
+          {installing ? <Spinner size={SpinnerSize.small} /> : 'Install'}
+        </PrimaryButton>
+      )}
+    </Stack>
+  )
+}
+
+const renderProjectItem = (project?: ProjectNode, _index?: number) => {
+  if (!project) {
+    return null
+  }
+
+  return (
+    <Stack verticalAlign="center" horizontal={true} tokens={{ childrenGap: 8 }}>
+      {project.id}
+      <Text variant="small">
+        {project.namespace}/{project.name}
+      </Text>
+    </Stack>
+  )
+}
+
+const ProjectSelector = ({ onSelect }: { onSelect: (projectId: string) => void }) => {
+  const [{ projects, loading, totalCount }, dispatcher] = useModule(ProjectsModule)
+
+  const [{ page, pageSize, query }, setProjectQuery] = useState<{
+    page: number
+    pageSize: number
+    query: string
+  }>({ page: 1, pageSize: 5, query: '' })
+
+  useEffect(() => {
+    dispatcher.getProjects({
+      page: page,
+      pageSize: pageSize,
+      query,
+      permission: Permission.Admin,
+      starred: false,
+    })
+  }, [dispatcher, page, pageSize, query])
+
+  useEffect(() => dispatcher.reset, [dispatcher])
+
+  const handlePageChange = useCallback((page: number, pageSize: number) => {
+    setProjectQuery((prev) => ({ page, pageSize, query: prev.query }))
+  }, [])
+
+  const handleRowClick = useCallback(
+    (project: ProjectNode | null) => {
+      if (project) {
+        onSelect(project.id)
+      }
+    },
+    [onSelect],
+  )
+
+  const handleSearchChange = useCallback((_e: any, query: string | undefined) => {
+    setProjectQuery((prev) => ({ ...prev, query: query || '' }))
+  }, [])
+
+  return (
+    <>
+      <SelectorContainer>
+        <ProjectSearchBar placeholder="Search projects" defaultValue={query} onChange={handleSearchChange} />
+        <Table
+          selectionMode={SelectionMode.none}
+          items={projects}
+          columns={[
+            {
+              key: 'project',
+              name: 'Project',
+              minWidth: 100,
+              flexGrow: 1,
+              onRender: (project) => (
+                <Stack tokens={{ childrenGap: 4 }}>
+                  <Text>{project.id}</Text>
+                  <Text variant="small" styles={{ root: { color: SharedColors.gray30 } }}>
+                    {project.namespace}/{project.name}
+                  </Text>
+                </Stack>
+              ),
+            },
+          ]}
+          isHeaderVisible={false}
+          enableShimmer={loading}
+          shimmerLines={6}
+          onRowClick={handleRowClick}
+          onRenderCell={renderProjectItem}
+        />
+      </SelectorContainer>
+      <Pagination
+        total={totalCount}
+        onChange={handlePageChange}
+        page={page}
+        pageSize={pageSize}
+        hideOnSinglePage={true}
+      />
+    </>
+  )
+}
+
+export const AppInstaller = () => {
+  const { appName } = useParams<RouteTypes['app']['install']>()
+
+  const [{ projectId }, updateQueryString] = useQueryString<{ projectId: string }>()
+
+  const [{ application, loading }, dispatcher] = useModule(ApplicationInstallerModule)
+
+  useEffect(() => {
+    dispatcher.getApplication({ appName })
+    return dispatcher.reset
+  }, [appName, dispatcher])
+
+  const handleSelectProject = useCallback(
+    (projectId: string) => {
+      updateQueryString({ projectId })
+    },
+    [updateQueryString],
+  )
+
+  const handleChangeProject = useCallback(() => {
+    updateQueryString({ projectId: undefined })
+  }, [updateQueryString])
+
+  if (!loading && application) {
+    if (!projectId) {
+      return (
+        <BodyContainer>
+          <CardContainer>
+            <Stack tokens={{ childrenGap: '16px' }} horizontalAlign="center">
+              <Persona imageUrl={application.avatarUrl || undefined} text={application.username} hidePersonaDetails />
+
+              <Title>Install {appName} for your project</Title>
+              <CenterText>Choose Project</CenterText>
+              <ProjectSelector onSelect={handleSelectProject} />
+            </Stack>
+          </CardContainer>
+        </BodyContainer>
+      )
+    } else {
+      return (
+        <BodyContainer>
+          <CardContainer>
+            <Stack tokens={{ childrenGap: '16px' }} horizontalAlign="center">
+              <Persona imageUrl={application.avatarUrl || undefined} text={application.username} hidePersonaDetails />
+              <Title>Install {appName} for your project</Title>
+
+              <Stack tokens={{ childrenGap: '4px' }}>
+                <CenterText>
+                  Project: {projectId} <IconButton iconProps={{ iconName: 'swap' }} onClick={handleChangeProject} />
+                </CenterText>
+                <CenterText>Choose permission you want to give the application</CenterText>
+              </Stack>
+
+              <Authorization projectId={projectId} appId={application.id} />
+            </Stack>
+          </CardContainer>
+        </BodyContainer>
+      )
+    }
+  } else {
+    return (
+      <BodyContainer>
+        <CardContainer>
+          <Spinner size={SpinnerSize.large} />
+        </CardContainer>
+      </BodyContainer>
+    )
+  }
+}

--- a/packages/platform/src/modules/apps/style.ts
+++ b/packages/platform/src/modules/apps/style.ts
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled'
+import { SearchBox, Text } from '@fluentui/react'
+
+import { Card } from '@perfsee/components'
+
+export const CardContainer = styled(Card)({
+  width: 550,
+  margin: '80px auto',
+  padding: '64px 88px',
+})
+
+export const SelectorContainer = styled.div(({ theme }) => ({
+  width: '100%',
+  border: '1px solid ' + theme.border.color,
+}))
+
+export const Title = styled.h1({
+  textAlign: 'center',
+  fontWeight: 600,
+  fontSize: '18px',
+})
+
+export const CenterText = styled(Text)({
+  textAlign: 'center',
+})
+
+export const ProjectSearchBar = styled(SearchBox)(({ theme }) => ({
+  width: '100%',
+  border: 'none',
+  borderBottom: '1px solid ' + theme.border.color,
+  borderRadius: 0,
+  ':hover': {
+    borderBottom: '1px solid ' + theme.border.color,
+  },
+}))

--- a/packages/platform/src/modules/components/auth-apps/index.tsx
+++ b/packages/platform/src/modules/components/auth-apps/index.tsx
@@ -63,6 +63,8 @@ export const AuthApps: FC<Props> = memo(({ projectId }) => {
     dispatcher.getAuthorizedApps(projectId)
   }, [dispatcher, projectId])
 
+  useEffect(() => dispatcher.reset, [dispatcher])
+
   return (
     <Stack>
       <Label>Authorized Applications</Label>

--- a/packages/platform/src/modules/project/list.module.ts
+++ b/packages/platform/src/modules/project/list.module.ts
@@ -20,7 +20,7 @@ import { Observable } from 'rxjs'
 import { switchMap, map, startWith, endWith } from 'rxjs/operators'
 
 import { GraphQLClient, createErrorCatcher } from '@perfsee/platform/common'
-import { ProjectsQuery, projectsQuery } from '@perfsee/schema'
+import { Permission, ProjectsQuery, projectsQuery } from '@perfsee/schema'
 
 export type ProjectNode = ProjectsQuery['projects']['edges'][0]['node']
 
@@ -59,13 +59,15 @@ export class ProjectsModule extends EffectModule<State> {
   }
 
   @Effect()
-  getProjects(payload$: Observable<{ page: number; pageSize: number; query: string; starred: boolean }>) {
+  getProjects(
+    payload$: Observable<{ page: number; pageSize: number; query: string; starred: boolean; permission?: Permission }>,
+  ) {
     return payload$.pipe(
-      switchMap(({ page, pageSize, starred, query }) =>
+      switchMap(({ page, pageSize, starred, query, permission }) =>
         this.client
           .query({
             query: projectsQuery,
-            variables: { input: { skip: (page - 1) * pageSize, first: pageSize }, starred, query },
+            variables: { input: { skip: (page - 1) * pageSize, first: pageSize }, starred, query, permission },
           })
           .pipe(
             createErrorCatcher('Failed to get projects list.'),

--- a/packages/platform/src/routes/lazy-modules.tsx
+++ b/packages/platform/src/routes/lazy-modules.tsx
@@ -31,3 +31,4 @@ export const FeaturesBundle = lazy(() => import(/* webpackChunkName: "home" */ '
 export const FeaturesLab = lazy(() => import(/* webpackChunkName: "home" */ '../modules/home/features/lab'))
 export const FeaturesSource = lazy(() => import(/* webpackChunkName: "home" */ '../modules/home/features/source'))
 export const Admin = lazy(() => import(/* webpackChunkName: "admin" */ '../modules/admin'))
+export const AppInstaller = lazy(() => import(/* webpackChunkName: "appInstaller" */ '../modules/apps'))

--- a/packages/platform/src/routes/routes.tsx
+++ b/packages/platform/src/routes/routes.tsx
@@ -38,6 +38,7 @@ import {
   FeaturesLab,
   FeaturesSource,
   Admin,
+  AppInstaller,
 } from './lazy-modules'
 
 export const Routes = ({ user, settings }: { user: User | null; settings: ApplicationSettings | null }) => {
@@ -67,6 +68,7 @@ export const Routes = ({ user, settings }: { user: User | null; settings: Applic
           <Route path={staticPath.me.home} component={Me} />
           <Route exact={true} path={staticPath.projects} component={ProjectListPage} />
           <Route path={staticPath.project.feature} component={ProjectFeaturePage} />
+          <Route path={staticPath.app.install} component={AppInstaller} />
           {user.isAdmin && <Route path={staticPath.admin.part} component={Admin} />}
           <Route path="*" render={NotFound} />
         </Switch>

--- a/packages/schema/src/graphql/application/application.gql
+++ b/packages/schema/src/graphql/application/application.gql
@@ -1,0 +1,7 @@
+query application($name: String!) {
+  application(name: $name) {
+    id
+    username
+    avatarUrl
+  }
+}

--- a/packages/schema/src/graphql/project/projects.gql
+++ b/packages/schema/src/graphql/project/projects.gql
@@ -1,5 +1,5 @@
-query projects($input: PaginationInput!, $starred: Boolean!, $query: String) {
-  projects(pagination: $input, starred: $starred, query: $query) {
+query projects($input: PaginationInput!, $starred: Boolean!, $query: String, $permission: Permission) {
+  projects(pagination: $input, starred: $starred, query: $query, permission: $permission) {
     edges {
       node {
         id

--- a/packages/schema/src/graphql/setting/application.gql
+++ b/packages/schema/src/graphql/setting/application.gql
@@ -1,6 +1,0 @@
-query application($id: Int!) {
-  application(id: $id) {
-    id
-    username
-  }
-}

--- a/packages/schema/src/server-schema.gql
+++ b/packages/schema/src/server-schema.gql
@@ -492,6 +492,7 @@ type User {
 
 type Application {
   username: String!
+  avatarUrl: String
 
   """issue created timestamp"""
   createdAt: DateTime!
@@ -1130,6 +1131,9 @@ type Query {
 
     """search project with git namespace/name"""
     query: String
+
+    """filter project with permission"""
+    permission: Permission
   ): PaginatedProjects!
   user: User
   searchUsers(query: String!): [SearchUserResult!]!
@@ -1162,7 +1166,7 @@ type Query {
   connections: [ConnectionType!]!
   devices: [DeviceType!]!
   availableOAuthProviders: [ExternalAccount!]!
-  application(id: Int!): Application!
+  application(id: Int, name: String): Application!
   applications(pagination: PaginationInput = {first: 10}): PaginatedApplications!
   applicationSettings: ApplicationSettings!
   zone: Zone!

--- a/packages/shared/src/routes/router.ts
+++ b/packages/shared/src/routes/router.ts
@@ -46,6 +46,7 @@ export interface RouteTypes {
     settings: Params<'projectId'> & Partial<Params<'settingName'>>
     jobTrace: Params<'projectId' | 'type' | 'entityId'>
   }
+  app: { home: Params<'appName'>; install: Params<'appName'> }
   admin: {
     home: void
     part: Partial<Params<'part'>>
@@ -97,6 +98,7 @@ export const staticPath = {
     settings: '/projects/:projectId/settings/:settingName?',
     jobTrace: '/projects/:projectId/jobs/:type/:entityId',
   },
+  app: { home: '/apps/:appName', install: '/apps/:appName/install' },
   admin: {
     home: '/admin',
     part: '/admin/:part?',
@@ -182,6 +184,10 @@ export const pathFactory = {
       '/projects/:projectId/jobs/:type/:entityId',
     ),
   },
+  app: {
+    home: makePathsFrom<FactoryParams<RouteTypes['app']['home']>>('/apps/:appName'),
+    install: makePathsFrom<FactoryParams<RouteTypes['app']['install']>>('/apps/:appName/install'),
+  },
   admin: {
     home: makePathsFrom<FactoryParams<RouteTypes['admin']['home']>>('/admin'),
     part: makePathsFrom<FactoryParams<RouteTypes['admin']['part']>>('/admin/:part?'),
@@ -243,6 +249,8 @@ export const titleFactory = {
     makeTitlesFrom('Setting {settingName} | {projectId} | Perfsee', data),
   '/projects/:projectId/jobs/:type/:entityId': (data: Record<string, any>) =>
     makeTitlesFrom('{type} job #{entityId} | {projectId} | Perfsee', data),
+  '/apps/:appName': (data: Record<string, any>) => makeTitlesFrom('Apps | Perfsee', data),
+  '/apps/:appName/install': (data: Record<string, any>) => makeTitlesFrom('Install {appName} | Apps | Perfsee', data),
   '/admin': (data: Record<string, any>) => makeTitlesFrom('Perfsee', data),
   '/admin/:part?': (data: Record<string, any>) => makeTitlesFrom('Perfsee', data),
   '/admin/settings': (data: Record<string, any>) => makeTitlesFrom('Perfsee', data),

--- a/packages/shared/src/routes/router.yaml
+++ b/packages/shared/src/routes/router.yaml
@@ -111,6 +111,13 @@ paths:
       jobTrace:
         path: /jobs/:type/:entityId
         title: '{type} job #{entityId}'
+  app:
+    base: /apps/:appName
+    title: 'Apps'
+    paths:
+      install:
+        path: /install
+        title: Install {appName}
   admin:
     base: /admin
     paths:


### PR DESCRIPTION
Third-party services can use an easy way to guide users to authorize their app.

```
https://perfsee.com/apps/<app-name>/install?action=Admin&returnUrl=<third-party-url>
```

<img width="1485" alt="图片" src="https://user-images.githubusercontent.com/13579374/212050646-c3d3cf4f-9f0f-420e-ae3e-a13f969fe9e0.png">
<img width="1520" alt="图片" src="https://user-images.githubusercontent.com/13579374/212050667-b1ff5329-bd22-414e-a5ea-480451d732cd.png">
