### PR TITLE
fix(rollup): override `options.toolkit` with `vite` always in vite's runtime

### DIFF
--- a/packages/plugins/rollup/src/index.ts
+++ b/packages/plugins/rollup/src/index.ts
@@ -55,12 +55,9 @@ export const PerfseePlugin = (userOptions: Options = {}): Plugin => {
   return {
     name: 'perfsee-rollup-plugin',
     configResolved(resolvedConfig: any) {
-      publicPath = resolvedConfig.base
-
       // vite only hook
-      if (!userOptions.toolkit) {
-        options.toolkit = 'vite'
-      }
+      publicPath = resolvedConfig.base
+      options.toolkit = 'vite'
     },
     moduleParsed(moduleInfo) {
       const { id } = moduleInfo


### PR DESCRIPTION
## To fix a problem
We need to prevent users's `options.toolkit` from being reset with `rollup` when running in Vite's runtime.

## How to reproduce
Include the config like `options.toolkit = 'vite'` when using the plugin.