### PR TITLE
fix(job-runner): fix call frame & dry run lighthouse when starting proxy server

### DIFF
--- a/packages/platform/src/modules/snapshots/components/snapshot-detail-content/pivot-content-overview/index.tsx
+++ b/packages/platform/src/modules/snapshots/components/snapshot-detail-content/pivot-content-overview/index.tsx
@@ -78,7 +78,7 @@ export const OverviewPivotContent = (props: Props) => {
       if (isLHCalculator(detail.id, categories?.performance)) {
         if (LighthouseScoreType.LCP === detail.id) {
           scores.push(
-            <Stack>
+            <Stack key={detail.id}>
               <LighthouseScoreBlock key={detail.id} detail={detail} colorful={true} />
               {(detail.score ?? 0) < 90 &&
                 // @ts-expect-error

--- a/packages/runner/lab/src/lighthouse/lighthouse-runtime/audits/cause-for-lcp.ts
+++ b/packages/runner/lab/src/lighthouse/lighthouse-runtime/audits/cause-for-lcp.ts
@@ -113,7 +113,14 @@ export class CauseForLCP extends Audit {
           longtasks: longtasks.filter((longtask) => {
             // @ts-expect-error
             const hotFunctionStackTraces = longtask.hotFunctionsStackTraces as FunctionStackTrace[][] | undefined
-            return hotFunctionStackTraces?.[0]?.[0].functionName !== '__puppeteer_evaluation_script__'
+            for (const stacks of hotFunctionStackTraces ?? []) {
+              for (const stack of stacks ?? []) {
+                if (stack.functionName === '__puppeteer_evaluation_script__') {
+                  return false
+                }
+              }
+            }
+            return true
           }),
           criticalPathForLcp,
           LcpElement,

--- a/packages/runner/lab/src/lighthouse/lighthouse-worker.ts
+++ b/packages/runner/lab/src/lighthouse/lighthouse-worker.ts
@@ -208,6 +208,8 @@ export abstract class LighthouseJobWorker extends JobWorker<LabJobPayload> {
         startProxyServer()
 
         const lhFlags = this.getLighthouseFlags()
+        lhFlags.customFlags ||= {}
+        lhFlags.customFlags!.dryRun = true
         // run page twice to cache api requests
         await this.runLh(this.payload.url, lhFlags)
         await this.runLh(this.payload.url, lhFlags)

--- a/packages/runner/source/src/source/index.ts
+++ b/packages/runner/source/src/source/index.ts
@@ -595,5 +595,7 @@ export class SourceJobWorker extends JobWorker<SourceAnalyzeJob> {
 }
 
 function getKeyForCallFrame(callFrame: CallFrame) {
-  return callFrame.url ? `${callFrame.url}:${callFrame.lineNumber}:${callFrame.columnNumber}` : undefined
+  // raw call frame's location is 0-based
+  // the source analyzer uses 1-based locations
+  return callFrame.url ? `${callFrame.url}:${callFrame.lineNumber + 1}:${callFrame.columnNumber + 1}` : undefined
 }

--- a/types/lighthouse/index.d.ts
+++ b/types/lighthouse/index.d.ts
@@ -36,6 +36,7 @@ module LH {
     customFlags?: {
       headers?: Record<string, Record<string, string>>
       reactProfiling?: boolean
+      dryRun?: boolean
     }
   }
 


### PR DESCRIPTION
1. parsing call frame uses 1-based line col number
2. dry run lighthouse when starting proxy server
3. filter longtask that is called by puppeteer evaluation script
4. fix a React component's key losing