### PR TITLE
feat(job-runner-lab): use benchmark index to throttling

### DIFF
--- a/packages/runner/lab/src/lighthouse/helpers/browser.ts
+++ b/packages/runner/lab/src/lighthouse/helpers/browser.ts
@@ -43,7 +43,7 @@ export async function createBrowser(options: BrowserOptions = {}) {
     chromeArgs.push('--host-rules=MAP * 127.0.0.1')
   }
 
-  const browser = await puppeteer.launch({
+  return puppeteer.launch({
     executablePath,
     ignoreHTTPSErrors: true,
     defaultViewport: {
@@ -53,15 +53,4 @@ export async function createBrowser(options: BrowserOptions = {}) {
     ...options,
     args: [...chromeArgs, ...(options.args ?? [])],
   })
-
-  // close default created tabs
-  await browser.pages().then((pages) => {
-    return Promise.allSettled(
-      pages.map(async (page) => {
-        await page.close()
-      }),
-    )
-  })
-
-  return browser
 }

--- a/packages/runner/lab/src/lighthouse/helpers/devices.ts
+++ b/packages/runner/lab/src/lighthouse/helpers/devices.ts
@@ -28,8 +28,24 @@ export type DeviceSchema = {
   }
 }
 
+export const DEFAULT_BENCHMARK_INDEX = 1000
+
 export const DEVICE_DESCRIPTORS: Record<string, DeviceSchema> = {
   no: {
+    formFactor: 'desktop',
+    cpuSlowdownMultiplier: 1,
+    viewport: {
+      width: 1920,
+      height: 1080,
+      deviceScaleFactor: 1,
+      isMobile: false,
+      hasTouch: false,
+      isLandscape: false,
+    },
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36 Edg/103.0.1264.37',
+  },
+  Desktop: {
     formFactor: 'desktop',
     cpuSlowdownMultiplier: 1,
     viewport: {

--- a/packages/runner/lab/src/lighthouse/lighthouse-runtime/index.ts
+++ b/packages/runner/lab/src/lighthouse/lighthouse-runtime/index.ts
@@ -35,14 +35,20 @@ export type MetricsRecord = {
   index: number
   lcp: number
   tbt: number
+  benchmarkIndex: number
+  cpuSlowdownMultiplier?: number
 }
 
-function getMedianValue(numbers: number[]) {
+export function getMedianValue(numbers: number[]) {
   const sorted = numbers.slice().sort((a, b) => a - b)
   if (sorted.length % 2 === 1) return sorted[(sorted.length - 1) / 2]
   const lowerValue = sorted[sorted.length / 2 - 1]
   const upperValue = sorted[sorted.length / 2]
   return (lowerValue + upperValue) / 2
+}
+
+export function getMeanValue(numbers: number[]) {
+  return numbers.reduce((a, b) => a + b, 0) / numbers.length
 }
 
 function getMedianSortValue(value: number, median: number) {
@@ -85,28 +91,6 @@ export function computeMedianRun(runs: MetricsRecord[]) {
   })
 
   return sortedByProximityToMedian[0].index
-}
-
-export function runsNotExceedMedianBy(diffScore: number, runs: MetricsRecord[]) {
-  const runsWithLCP = filterToValidRuns(runs, 'lcp')
-
-  if (!runsWithLCP.length) {
-    return runs
-  }
-
-  const runsWithTBT = filterToValidRuns(runsWithLCP, 'tbt')
-  if (!runsWithTBT.length) {
-    return runsWithLCP
-  }
-
-  const medianLCP = getMedianValue(runsWithLCP.map((run) => run.lcp))
-  const medianTBT = getMedianValue(runsWithTBT.map((run) => run.tbt))
-
-  return runsWithTBT.filter((run) => {
-    const tbtPass = run.tbt - medianTBT <= diffScore && run.tbt - medianTBT >= -diffScore
-    const lcpPass = run.lcp - medianLCP <= diffScore && run.lcp - medianLCP >= -diffScore
-    return tbtPass && lcpPass
-  })
 }
 
 export async function lighthouse(url?: string, { customFlags, ...flags }: LH.Flags = {}) {

--- a/packages/utils/src/consts.ts
+++ b/packages/utils/src/consts.ts
@@ -29,6 +29,7 @@ export const CONNECTIONS = [
 ]
 
 export const DEVICES = [
+  { id: 'Desktop', value: 'Low-End Desktop', cpuSlowdownMultiplier: 1 },
   { id: 'iPhone6', value: 'iPhone 6', cpuSlowdownMultiplier: 4 },
   { id: 'iPhone8', value: 'iPhone 8', cpuSlowdownMultiplier: 2 },
   { id: 'iPhoneX', value: 'iPhone X', cpuSlowdownMultiplier: 2 },


### PR DESCRIPTION
These changes are intended to make the results more stable.
- add low-end desktop profile
- use dynamic cpu throttling. refer: https://github.com/GoogleChrome/lighthouse/blob/main/docs/throttling.md#benchmarking-cpu-power
- filter results that has a obvious variability of `benchmarkIndex` when proxy is enabled