### PR TITLE
fix: should skip upload when no project id

### DIFF
--- a/packages/plugins/utils/src/build-upload-client.ts
+++ b/packages/plugins/utils/src/build-upload-client.ts
@@ -87,6 +87,7 @@ export class BuildUploadClient {
 
     if (!this.options.project) {
       console.info(chalk.yellow('[perfsee] no project id provided, skip uploading build.'))
+      return
     }
 
     if (this.options.processStats) {


### PR DESCRIPTION
it still trigger upload period when no project id provided